### PR TITLE
feat: allow CORS

### DIFF
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -4,6 +4,9 @@ module.exports = function (app) {
   app.use(
     createProxyMiddleware(process.env.REACT_APP_MAINNET_SERVICE_URL, {
       target: process.env.REACT_APP_MAINNET_SERVICE_PROXY_URL,
+      onProxyRes: function (proxyRes, req, res) {
+        proxyRes.headers["Access-Control-Allow-Origin"] = "*"
+      },
       changeOrigin: true,
       pathRewrite: (path) => {
         return path.replace(process.env.REACT_APP_MAINNET_SERVICE_URL, "")
@@ -14,6 +17,9 @@ module.exports = function (app) {
   app.use(
     createProxyMiddleware(process.env.REACT_APP_TESTNET_SERVICE_URL, {
       target: process.env.REACT_APP_TESTNET_SERVICE_PROXY_URL,
+      onProxyRes: function (proxyRes, req, res) {
+        proxyRes.headers["Access-Control-Allow-Origin"] = "*"
+      },
       changeOrigin: true,
       pathRewrite: (path) => {
         return path.replace(process.env.REACT_APP_TESTNET_SERVICE_URL, "")


### PR DESCRIPTION
- allow cross-origin resource sharing for the api http request as quadswap.finance calling the subdomain api.quadswap.finance is considered cross-origin and no data is returned 