### PR TITLE
feat: token api request

### DIFF
--- a/src/rest/useAPI.ts
+++ b/src/rest/useAPI.ts
@@ -359,7 +359,8 @@ const useAPI = () => {
           }
     ) => {
       const { type, ...params } = query
-      const url = `${service}/tx/${type}`.toLowerCase()
+      const originalApi = "https://api.terraswap.io"
+      const url = `${originalApi}/tx/${type}`.toLowerCase()
       const res = (await axios.get(url, { params })).data
       return res.map((data: Msg.Amino | Msg.Amino[]) => {
         return (Array.isArray(data) ? data : [data]).map((item: Msg.Amino) => {

--- a/src/rest/useAPI.ts
+++ b/src/rest/useAPI.ts
@@ -248,32 +248,34 @@ const useAPI = () => {
       console.log(error)
     }
 
+    /* This while block is spamming failing API requests
     while (true) {
       const url = getURL(factory, {
         pairs: { limit: 30, start_after: lastPair },
       })
       const pairs: PairsResponse = (await axios.get(url)).data
-
+      
       if (!Array.isArray(pairs?.result?.pairs)) {
         // node might be down
         break
       }
-
+      
       if (pairs.result.pairs.length <= 0) {
         break
       }
-
+      
       pairs.result.pairs
-        .filter(
-          (pair) =>
-            !isBlacklisted(pair?.asset_infos?.[0]) &&
-            !isBlacklisted(pair?.asset_infos?.[1])
+      .filter(
+        (pair) =>
+        !isBlacklisted(pair?.asset_infos?.[0]) &&
+        !isBlacklisted(pair?.asset_infos?.[1])
         )
         .forEach((pair) => {
           result.pairs.push(pair)
         })
-      lastPair = pairs.result.pairs.slice(-1)[0]?.asset_infos
-    }
+        lastPair = pairs.result.pairs.slice(-1)[0]?.asset_infos
+      }
+      */
     return result
   }, [service, factory, getURL])
 


### PR DESCRIPTION
- comment out and remove while block that sends a large payload of failing api requests that is intended to get token data
- use the original api endpoint `api.terraswap.io` for the `tx/{type}` api request that is used to get the price of the second asset in the swap